### PR TITLE
Stop savepoint call overwriting core moodle version!

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -72,7 +72,7 @@ function xmldb_local_mobile_upgrade($oldversion) {
             $dbman->drop_table($oldtable);
         }
 
-        upgrade_main_savepoint(true, 2014060300);
+        upgrade_plugin_savepoint(true, 2014060300, 'local', 'mobile');
     }
     return true;
 }


### PR DESCRIPTION
This is overwriting core moodles save point!

So say you're on Moodle 2.7 with a version of: 2014051202.07
local_mobile comes along and sets it to 2014060300.

This now means that if I upgrade moodle to something else, all the upgrade steps between 20140512 and 20140603 will be skipped, as it believes its already on that version!
